### PR TITLE
JustType: use a relative margin for main field

### DIFF
--- a/app/JustType.js
+++ b/app/JustType.js
@@ -73,8 +73,8 @@ enyo.kind({
 		this.delayedDoSearch = Util.debounce(undefined, enyo.bind(this, "doSearch"), 0.5);
 		this.wasValidEmailOrWebString = false;
 		this.$.radioGroup.setValue(1);
-		var size = (Math.min(window.innerWidth, window.innerHeight) * 0.95) + 'px';
-		this.$.searchField.applyStyle('width', size);
+		this.$.searchField.applyStyle('margin-left', '2%');
+		this.$.searchField.applyStyle('margin-right', '2%');
 	},
 	loadLibraries: function() {
 		try {


### PR DESCRIPTION
This fixes an issue with Qt 5.12.5 where window.innerWidth isn't
valued yet when the script is executed. Also, it helps the field to
scale automatically.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>