### PR TITLE
luna-applauncher: Add requiredPermissions to appinfo.json

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -6,6 +6,6 @@
 	"id": "com.palm.launcher",
 	"icon": "icon.png",
 	"theme":"palm-dark",
-	"visible": "false"
+	"visible": "false",
+	"requiredPermissions": ["applications", "application.internal", "database", "database.internal", "services", "system"]
 }
-


### PR DESCRIPTION
Trying to solve:

May 20 08:26:12 qemux86-64 user.err ls-hubd: [] [pmlog] ls-hubd LSHUB_NO_NAME_PERMS {"APP_ID":"com.palm.launcher","ROLE_ID":"/usr/sbin/LunaWebAppManager","EXE":"/usr/sbin/LunaWebAppManager"} Executable: "/usr/sbin/LunaWebAppManager" (cmdline: /usr/sbin/LunaWebAppManager
2020-05-20T06:26:12.879130Z [11.281286475] user.err LunaWebAppManager [] <default-lib> LS_REQ_NAME {"FILE":"transport.c","LINE":1931} Invalid permissions for com.palm.launcher

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>