### PR TITLE
appinfo.json: Fix typo

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -7,5 +7,5 @@
 	"icon": "icon.png",
 	"theme":"palm-dark",
 	"visible": "false",
-	"requiredPermissions": ["applications", "application.internal", "database", "database.internal", "services", "system"]
+	"requiredPermissions": ["applications", "applications.internal", "database", "database.internal", "services", "system"]
 }


### PR DESCRIPTION
So things work properly :)

2020-06-22T15:49:06.618391Z [22.068565863] user.warning LunaAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.launcher-1002","CATEGORY":"/","METHOD":"listLaunchPoints"} Service security groups don't allow method call.
2020-06-22T15:49:08.427208Z [23.877384646] user.warning service.accounts [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.launcher-1002","CATEGORY":"/","METHOD":"listAccountTemplates"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>